### PR TITLE
Add favicon icon and see also in meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/WEBXELA/brand-images/e84c6074fba81c45b6ee4f0e57ac798890e6c352/logo/webxela-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="see also" content="WEBXELA, Cloud Solutions, AI Solutions, Development Solutions" />
     <title>WEBXELA - Cloud, AI & Development Solutions</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>


### PR DESCRIPTION
Add favicon icon and "see also" meta tag in `index.html`.

* Update the favicon icon path to "https://raw.githubusercontent.com/WEBXELA/brand-images/e84c6074fba81c45b6ee4f0e57ac798890e6c352/logo/webxela-logo.svg".
* Add a "see also" meta tag with the content "WEBXELA, Cloud Solutions, AI Solutions, Development Solutions".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/YatharthChauhan2362/webxela-main/pull/1?shareId=6fa7d003-37ef-4006-9486-ef7fa7d370e9).